### PR TITLE
Fix link to LangChain MRLK reference

### DIFF
--- a/docs/advanced_applications/mrkl.md
+++ b/docs/advanced_applications/mrkl.md
@@ -122,5 +122,5 @@ J-1 (Jurassic 1)(@lieberjurassic) LLM.
 
 ## More
 
-See [this example](https://langchain.readthedocs.io/en/latest/examples/agents/mrkl.html) of a MRKL System
+See [this example](https://langchain.readthedocs.io/en/latest/modules/agents/implementations/mrkl.html) of a MRKL System
 built with LangChain.


### PR DESCRIPTION
This updates a broken link to LangChain MRLK

Old Link:
https://langchain.readthedocs.io/en/latest/examples/agents/mrkl.html

New Link:
https://langchain.readthedocs.io/en/latest/modules/agents/implementations/mrkl.html