### PR TITLE
:pencil: Fix typo where the body mentions davinci-002 but the trydyno uses davinci-003

### DIFF
--- a/docs/intermediate/chain_of_thought.md
+++ b/docs/intermediate/chain_of_thought.md
@@ -28,8 +28,8 @@ results.
 
 ## Example
 
-Here are a few demos. The first shows GPT-3 (davinci-002)
-failing to solve a simple word problem. The second shows GPT-3 (davinci-002) succesfully solving the same problem, by using CoT prompting.
+Here are a few demos. The first shows GPT-3 (davinci-003)
+failing to solve a simple word problem. The second shows GPT-3 (davinci-003) succesfully solving the same problem, by using CoT prompting.
 
 #### Incorrect
 


### PR DESCRIPTION
Fix a small typo.

Closes #251 