### PR TITLE
Apply custom style for tooltip anchors

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -58,3 +58,10 @@ div[role="tooltip"] a {
 div[itemscope][itemtype*="DefinedTerm"] span[itemprop="description"] {
   color: var(--ifm-toc-link-color);
 }
+a[data-tooltip-html] {
+  border-bottom: 1px dashed;
+  cursor: help;
+}
+a[data-tooltip-html]:hover {
+  text-decoration: none;
+}


### PR DESCRIPTION
Apply custom style to differentiate tooltips anchors from default navigate anchors:

![image](https://user-images.githubusercontent.com/7807925/218747280-6ac2d6f7-4d80-43cc-9be3-8dff480f055a.png)

Thanks