### PR TITLE
Fix: avoids page scroll on tooltip anchor click

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@docusaurus/preset-classic": "^2.2.0",
         "@docusaurus/theme-mermaid": "^2.2.0",
         "@mdx-js/react": "^1.6.22",
-        "@renatonagliati/remark-auto-glossary": "git://github.com/renatonagliati/remark-auto-glossary.git#4fe9231d47dbc5c54966baa83a9d7ef50075057d",
+        "@renatonagliati/remark-auto-glossary": "git://github.com/renatonagliati/remark-auto-glossary.git#fed3f0983592ea15298b54b82fc92acc53359c25",
         "clsx": "^1.2.1",
         "cspell": "^6.17.0",
         "hast-util-is-element": "^1.1.0",
@@ -3377,9 +3377,9 @@
       "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g=="
     },
     "node_modules/@renatonagliati/remark-auto-glossary": {
-      "version": "0.2.0",
-      "resolved": "git+ssh://git@github.com/renatonagliati/remark-auto-glossary.git#4fe9231d47dbc5c54966baa83a9d7ef50075057d",
-      "integrity": "sha512-xK5kIRMpSWzPfByQQ8ukTP3Q53lDe4ziHXWYWo6DPjATnvpnYjOPpRKTBKOx6MGYtao2ZnAkeGkEybwxpBd9RQ==",
+      "version": "0.3.0",
+      "resolved": "git+ssh://git@github.com/renatonagliati/remark-auto-glossary.git#fed3f0983592ea15298b54b82fc92acc53359c25",
+      "integrity": "sha512-I4BDVGeNJ3OZh+fbMLYRZHoyMvFuklblTrH2GXCxmVZSYyq7Pm4H9Oj+1TuXP/nYI1KS3JyPiCy+yHIDk/iOmQ==",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0",
@@ -18251,9 +18251,9 @@
       "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g=="
     },
     "@renatonagliati/remark-auto-glossary": {
-      "version": "git+ssh://git@github.com/renatonagliati/remark-auto-glossary.git#4fe9231d47dbc5c54966baa83a9d7ef50075057d",
-      "integrity": "sha512-xK5kIRMpSWzPfByQQ8ukTP3Q53lDe4ziHXWYWo6DPjATnvpnYjOPpRKTBKOx6MGYtao2ZnAkeGkEybwxpBd9RQ==",
-      "from": "@renatonagliati/remark-auto-glossary@git://github.com/renatonagliati/remark-auto-glossary.git#4fe9231d47dbc5c54966baa83a9d7ef50075057d",
+      "version": "git+ssh://git@github.com/renatonagliati/remark-auto-glossary.git#fed3f0983592ea15298b54b82fc92acc53359c25",
+      "integrity": "sha512-I4BDVGeNJ3OZh+fbMLYRZHoyMvFuklblTrH2GXCxmVZSYyq7Pm4H9Oj+1TuXP/nYI1KS3JyPiCy+yHIDk/iOmQ==",
+      "from": "@renatonagliati/remark-auto-glossary@git://github.com/renatonagliati/remark-auto-glossary.git#fed3f0983592ea15298b54b82fc92acc53359c25",
       "requires": {
         "js-yaml": "^4.1.0",
         "mdast-util-heading-range": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "react-tooltip": "^5.7.4",
-    "@renatonagliati/remark-auto-glossary": "git://github.com/renatonagliati/remark-auto-glossary.git#4fe9231d47dbc5c54966baa83a9d7ef50075057d",
+    "@renatonagliati/remark-auto-glossary": "git://github.com/renatonagliati/remark-auto-glossary.git#fed3f0983592ea15298b54b82fc92acc53359c25",
     "@benchmark-urbanism/remark-bibtex": "https://github.com/trigaten/remark-bibtex.git",
     "@benrbray/micromark-extension-cite": "^1.0.0",
     "@docusaurus/core": "^2.2.0",


### PR DESCRIPTION
- Uses **remark-auto-glossary plugin v0.3.0** to avoid page scroll on tooltip anchor click

Currently, when clicking on the anchor, the page scrolls to the top. On the desktop this has little impact as the tooltip appears when hovering the mouse over it, however, on mobile the tooltip is only shown after the touch (..and with that the page is scrolled and interferes with the user experience).

Thanks