### PR TITLE
doc: change typo link in reliability/debiasing.md

### DIFF
--- a/docs/reliability/debiasing.md
+++ b/docs/reliability/debiasing.md
@@ -8,7 +8,7 @@ This page covers a few simple techniques to debias your prompts.
 
 ## Exemplar Debiasing
 
-Depending on their distribution and order within the prompt, %%exemplars|exemplars%% may bias LLM outputs(@si2022prompting). This is discussed to some extent in the [What's in a Prompt](http://localhost:3000/docs/intermediate/whats_in_a_prompt) page.
+Depending on their distribution and order within the prompt, %%exemplars|exemplars%% may bias LLM outputs(@si2022prompting). This is discussed to some extent in the [What's in a Prompt](http://learnprompting.org/docs/intermediate/whats_in_a_prompt) page.
 
 ### Distribution
 


### PR DESCRIPTION
change typo link in reliability/debiasing.md
http://localhost:3000/docs/intermediate/whats_in_a_prompt to https://learnprompting.org/docs/intermediate/whats_in_a_prompt