### PR TITLE
Fix conversation history replace mechanism in Applied Prompting code snippet

### DIFF
--- a/docs/applied_prompting/build_chatgpt.md
+++ b/docs/applied_prompting/build_chatgpt.md
@@ -135,7 +135,7 @@ Chatbot:"""
 
 def get_response(conversation_history, user_input):
     prompt = chatbot_prompt.replace(
-        "<conversation_history>", conversation_history).replace("<user input>", user_input)
+        "<conversation history>", conversation_history).replace("<user input>", user_input)
 
     # Get the response from GPT-3
     response = openai.Completion.create(

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/applied_prompting/build_chatgpt.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/applied_prompting/build_chatgpt.md
@@ -134,7 +134,7 @@ Chatbot:"""
 
 def get_response(conversation_history, user_input):
     prompt = chatbot_prompt.replace(
-        "<conversation_history>", conversation_history).replace("<user input>", user_input)
+        "<conversation history>", conversation_history).replace("<user input>", user_input)
 
     # Get the response from GPT-3
     response = openai.Completion.create(


### PR DESCRIPTION
Replaced '_' with ' ' so that it can actually replace the conversation history in the prompt in Applied Prompting section. Conversation history is actually represented as `<conversation history>`, not `<conversation_history>`