### PR TITLE
Doc: fix external link in mrkl.md

### DIFF
--- a/docs/advanced_applications/mrkl.md
+++ b/docs/advanced_applications/mrkl.md
@@ -122,5 +122,5 @@ J-1 (Jurassic 1)(@lieberjurassic) LLM.
 
 ## More
 
-See [this example](https://langchain.readthedocs.io/en/latest/modules/agents/implementations/mrkl.html) of a MRKL System
+See [this example](https://python.langchain.com/en/latest/modules/agents/agents/examples/mrkl.html) of a MRKL System
 built with LangChain.


### PR DESCRIPTION
Drive-by fix of external link to the LongChain MRKL example