### PR TITLE
Fix small typo in coding_assistance.md

### DIFF
--- a/docs/basic_applications/coding_assistance.md
+++ b/docs/basic_applications/coding_assistance.md
@@ -103,7 +103,7 @@ for i in range(num_points):
 
 ## Debugging
 
-Not only can ChatGPT detect syntax errors in code, but it can also find logical errors that would crop up when code is executed. Below is an example of a Python script that eventually causes a division by zero error one line 4 due to a logical error on line 3.  Try this simple prompt to find and fix the error:
+Not only can ChatGPT detect syntax errors in code, but it can also find logical errors that would crop up when code is executed. Below is an example of a Python script that eventually causes a division by zero error on line 4 due to a logical error on line 3.  Try this simple prompt to find and fix the error:
 
 ```text
 Please debug this Python code:  


### PR DESCRIPTION
Replaces "one" with "on" in the Debugging section of docs/basic_applications/coding_assistance.md