### PR TITLE
Typo fix: bullet point to angle bracket

### DIFF
--- a/docs/products.md
+++ b/docs/products.md
@@ -464,7 +464,7 @@ Writes content, predicts outcomes or answers questions at your command.
 > AI code writing assistant for data scientists, engineers, and analysts. Get code completions and suggestions as you type.
 
 - [regex.ai](https://regex.ai/)
-- AI-Powered Regular Expression Solver
+> AI-Powered Regular Expression Solver
 
 ## Sales and Marketing
 


### PR DESCRIPTION
Found a typo in the prompted products page where an entry used an additional bullet point (`-`) instead of a right-pointing angle bracket (`>`) for the product description.