### PR TITLE
Update broken link

### DIFF
--- a/docs/advanced_applications/mrkl.md
+++ b/docs/advanced_applications/mrkl.md
@@ -122,5 +122,5 @@ J-1 (Jurassic 1)(@lieberjurassic) LLM.
 
 ## More
 
-See [this example](https://python.langchain.com/en/latest/modules/agents/agents/examples/mrkl.html) of a MRKL System
+See [this example](https://python.langchain.com/docs/modules/agents/how_to/mrkl) of a MRKL System
 built with LangChain.


### PR DESCRIPTION
The LangChain documentation seems to have had an overhaul, so the current link is broken.

I've looked for the most likely candidate page that this link previously pointed to, and replaced it with that link.