### PR TITLE
URL pointing to incorrect content

### DIFF
--- a/docs/basics/intro.md
+++ b/docs/basics/intro.md
@@ -38,7 +38,7 @@ or give you a solid starting point. Here are a few of our favorite applications 
 - Generating marketing content
 - Explaining and simplifying content
 
-See more use cases [here](@site/docs//basic_applications/introduction.md).
+See more use cases [here](https://learnprompting.org/docs/category/-basic-applications).
 
 ## How do I get started with Generative AI?
 


### PR DESCRIPTION
`See more use cases [here](https://learnprompting.org/assets/files/introduction-9a8870b2a535e1cda88b2b94bed1188b.md)`
in the **Why should I care about Generative AI?** section of the **intro page** is corrected to 
`See more use cases [here](https://learnprompting.org/docs/category/-basic-applications)`