### PR TITLE
Adding Python to the list of supported languages

### DIFF
--- a/docs/basic_applications/coding_assistance.md
+++ b/docs/basic_applications/coding_assistance.md
@@ -19,6 +19,7 @@ You can use ChatGPT for debugging, code generation, reformatting, commenting, an
 | Forth       | Tcl            | Groovy              | Vlang                 |
 | Ada         | SQL            | Scala Native        | Erlang                |
 |             | Java           |                     |                       |
+|             | Python         |                     |                       |
 
 ## Code Generation
 


### PR DESCRIPTION
I found it weird, that all examples below use Python, but this is missing from the table of supported languages. As first released in 1991, it is older than Java and newer than Perl. Therefore under "Old" category.