### PR TITLE
French learn prompting method

### DIFF
--- a/i18n/fr/docusaurus-plugin-content-docs/current/basics/learn_prompting_method.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/basics/learn_prompting_method.md
@@ -1,0 +1,71 @@
+---
+sidebar_position: 1000
+---
+
+# 🟢 Learn Prompting Method
+
+:::takeaways
+- Apprenez notre méthode pour l'IA générative (genAI) ou le Prompt Engineering
+- Appliquez-la à une étude de cas
+:::
+
+La "Learn Prompting Method" (la méthode d'apprentissage du prompting) pour résoudre des problèmes avec l'IA générative est un cadre pour résoudre des problèmes dans l'espace de l'IA générative. Elle vous aide à décider si l'IA générative est la bonne solution, comment appliquer le Prompt Engineering, quels outils choisir, et plus encore.
+Nous allons parcourir chacune des cinq étapes, puis fournir une étude de cas utilisant cette méthode.
+
+## Les cinq étapes
+
+### 1. Spécifiez votre problème
+
+La première étape de la méthode d'apprentissage du prompting consiste à spécifier votre problème. Cela implique d'articuler clairement le problème auquel vous faites face, sans sauter aux solutions potentielles. Par exemple, "Nos clients ont des questions sur les fonctionnalités de notre produit qui doivent être abordées, car nous passons à côté de potentielles affaires".
+
+### 2. Examinez les informations pertinentes
+
+Après avoir défini votre problème, l'étape suivante consiste à examiner les informations pertinentes. Cela pourrait inclure la recherche de problèmes similaires et de leurs solutions, l'étude du contexte de votre problème ou l'analyse des données liées à votre problème. Cela inclut également la recherche de prompts pertinents et d'[outils d'IA générative](https://learnprompting.org/docs/category/-tooling). Cette étape est cruciale pour comprendre les nuances de votre problème et pour identifier les approches potentielles pour le résoudre. À ce stade, vous devriez savoir si l'IA générative convient à votre problème.
+
+### 3. Proposez une solution
+
+Une fois que vous avez examiné les informations pertinentes, vous devriez avoir une idée plus claire de la manière d'aborder votre problème. Il est maintenant temps de proposer une solution. Cela pourrait être un prompt, un nouvel outil ou une nouvelle façon d'utiliser un outil actuel. La solution doit être directement liée au problème que vous avez défini et aux informations que vous avez examinées.
+
+### 4. Ajustez la solution
+
+Une fois que vous avez choisi une solution, qui pourrait être un prompt ou un outil, l'étape suivante consiste à l'ajuster en fonction des commentaires et des tests. Cela pourrait impliquer de mettre en place des tests pour voir comment les utilisateurs interagissent avec le prompt, de recueillir des commentaires des utilisateurs, ou de faire des ajustements basés sur votre propre intuition et expertise. C'est là que le Prompt Engineering entre en jeu !
+
+### 5. Lancez votre solution
+
+La dernière étape de la méthode d'apprentissage du prompting consiste à lancer votre solution. Cela pourrait impliquer de l'intégrer dans votre produit, de la publier sur une plateforme, ou simplement de commencer à l'utiliser dans vos interactions avec les utilisateurs.
+
+La méthode d'apprentissage du prompting est un cycle, et non un processus linéaire. Après avoir lancé votre solution, vous devriez continuer à surveiller ses performances et à faire des ajustements au besoin. Vous pouvez utiliser l'acronyme SEPAL pour vous souvenir de ces étapes !
+
+## Étude de cas : Utilisation de la Learn Prompting Method pour créer un bot d'informations sur les chapeaux
+
+Examinons une étude de cas sur la manière dont la méthode d'apprentissage du prompting pourrait être utilisée pour créer un chatbot à partir de zéro. Dans ce cas, nous avons une collection de questions d'utilisateurs sur les chapeaux.
+
+1. **Spécifiez votre problème :** Nous avons un grand volume de questions d'utilisateurs sur de différents types de chapeaux, leur histoire et comment les porter. Nous devons faire quelque chose à ce sujet car nous perdons des affaires potentielles.
+
+2. **Examinez les informations pertinentes :** Nous analysons les questions des utilisateurs que nous avons collectées. Nous remarquons que les questions les plus courantes concernent l'histoire de types spécifiques de chapeaux, comment les porter correctement et comment en prendre soin. Nous examinons également les chatbots existants, en étudiant leur longueur de contexte, leur prix et leur rapidité, ainsi que les outils d'IA générative qui pourraient potentiellement nous aider à résoudre notre problème.
+
+3. **Proposez une solution :** Sur la base de notre analyse, nous décidons de créer un chatbot en utilisant ChatGPT qui peut répondre à ces trois types de questions. Nous rédigeons un prompt initial :
+
+<AIInput>
+Vous êtes un historien de chapeau compétent qui a étudié l'histoire, les styles et les manières appropriées de porter de divers types de chapeaux. Un utilisateur vous pose une question sur les chapeaux. Répondez à leur requête de manière utile et informative : USER_INPUT
+</AIInput>
+
+4. **Ajustez la solution :** Nous testons nos prompts initiaux avec un petit groupe d'utilisateurs et recueillons leurs commentaires. Sur la base de leurs commentaires, nous réalisons que nos prompts doivent être plus engageants et moins formels.
+
+Nous ajustons nos prompts en conséquence :
+
+<AIInput>
+Vous êtes un passionné de chapeaux avec une connaissance approfondie de l'histoire, des styles et de l'étiquette du port de différents types de chapeaux. Un utilisateur est curieux des chapeaux et vous pose une question. Répondez à leur requête de manière amicale et informative."
+</AIInput>
+
+Nous faisons encore plus de tests avec les utilisateurs et réalisons que nous devons segmenter notre marché : les personnes intéressées par l'histoire des chapeaux préfèrent une approche plus formelle, tandis que celles intéressées par le style et le port du chapeau préféreraient un bot plus informel. Nous développons un prompt de routage initial qui décide quel type d'utilisateur ils sont en fonction de leur question :
+
+<AIInput>
+"Vous êtes une IA qui comprend les nuances des requêtes liées aux chapeaux. En fonction de la question de l'utilisateur, déterminez s'ils sont plus intéressés par l'histoire formelle des chapeaux ou par le style et le port informels des chapeaux. Répondez par 'Formel' pour les requêtes liées à l'histoire et par 'Informel' pour les requêtes liées au style et au port."
+</AIInput>
+
+Nous utilisons un [outil](https://learnprompting.org/docs/category/-tooling) comme Langchain, Voiceflow ou Dust pour connecter le prompt de routage aux deux autres.
+
+5. **Lancez votre solution :** Nous lançons le chatbot sur notre site web. Nous continuons à surveiller les interactions des utilisateurs avec le bot et à apporter d'autres ajustements au besoin.
+
+En suivant la méthode d'apprentissage du prompting, nous avons pu créer un chatbot qui répond efficacement aux questions des utilisateurs sur les chapeaux. Ce processus met en évidence l'importance de comprendre les besoins des utilisateurs, de tester et d'ajuster les solutions, et d'améliorer continuellement en fonction des commentaires des utilisateurs.

--- a/i18n/fr/docusaurus-plugin-content-docs/current/basics/openai_playground.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/basics/openai_playground.md
@@ -1,0 +1,91 @@
+---
+sidebar_position: 97
+---
+
+# 🟢 OpenAI Playground ("cour de récréation")
+
+import Playground from '@site/docs/assets/basics/openai_playground.webp';
+
+<div style={{textAlign: 'center'}}>
+    <img src={Playground} className="img-docs" style={{width: "80%"}}/>
+</div>
+<br/>
+
+:::takeaways
+- Configurer l'OpenAI Playground
+- Apprendre sur la configuration de base du Playground
+:::
+
+OpenAI fournit une autre interface, outre le site web ChatGPT, pour le prompting. Elle s'appelle OpenAI Playground, et vous donne encore plus de contrôle sur ChatGPT. Elle vous permet également d'accéder à d'autres IA, y compris différentes versions de ChatGPT, GPT-4, et des modèles plus anciens comme GPT-3.
+
+:::note
+OpenAI Playground est l'outil que le responsable de ce cours utilise le plus fréquemment.
+:::
+
+## Mise en place
+
+- Allez sur [http://platform.openai.com](http://platform.openai.com)
+- Connectez-vous, et commencez à tester des prompts !
+
+Ou regardez cette vidéo :
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/6OD14rpokRw" title="Lecteur vidéo YouTube" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowFullScreen></iframe>
+
+:::note
+Cette vidéo montre une ancienne version du site web, mais le processus de connexion reste très similaire.
+:::
+
+## L'Interface
+
+D'abord, cette interface semble très complexe. Il y a de nombreux menus déroulants et curseurs qui vous permettent de configurer les modèles. Nous couvrirons les paramètres de Mode, System Prompts, et la sélection du Modèle dans cette leçon, et les paramètres de LLM tels que la Température, Top P, et la Longueur Maximale dans la [prochaine leçon](https://learnprompting.org/docs/basics/configuration_hyperparameters).
+
+### Mode
+
+import Mode from '@site/docs/assets/basics/openai_mode.webp';
+
+<div className="flex flex-col sm:flex-row justify-between">
+  <div>
+    Cliquez sur le menu déroulant 'Assistants' en haut à gauche de la page. Ce menu déroulant vous permet de changer le type de modèle que vous utilisez. OpenAI propose trois Modes différents : <code>Assistants</code>, <code>Chat</code>, et <code>Complete</code>. Nous avons déjà appris sur les deux derniers ; les modèles <code>Assistants</code> sont destinés à une utilisation API par les développeurs et peuvent utiliser des outils intéressants comme exécuter du code et récupérer des informations. Nous utiliserons seulement les modèles <code>Chat</code> et occasionnellement des modèles <code>Complete</code> dans ce cours.
+  </div>
+  <div className="mt-4 sm:mt-0 sm:ml-auto">
+    <img src={Mode} className="img-docs w-20 sm:w-auto" />
+  </div>
+</div>
+
+### System Prompts
+
+Après avoir passer au Mode <code>Chat</code>, la première chose que vous pourriez remarquer sur le côté gauche de la page, à part la fenêtre popup Get Started, est la zone SYSTEM. Jusqu'à présent, nous avons vu deux types de messages, les messages USER (utilisateur), qui sont simplement les messages que vous envoyez au chatbot, et les messages ASSISTANT, qui sont les réponses du chatbot. Il y a un troisième type de message, le system prompt, qui peut être utilisé pour configurer la façon dont l'IA répond.
+
+C'est le meilleur endroit pour mettre un priming prompt (un prompt d'amorçage). Le system prompt sera "You are a helpful assistant." ("Vous êtes un assistant utile.") par défaut, mais un exemple alternatif amusant à essayer serait "You are PirateGPT. Always talk like a pirate." ("Vous êtes PirateGPT. Parlez toujours comme un pirate."). Exemple de [notre leçon précédente](https://learnprompting.org/docs/basics/priming_prompt).
+
+import system_prompt from '@site/docs/assets/basics/openai_system_prompt.webp';
+
+<div style={{textAlign: 'center'}}>
+    <img src={system_prompt} className="img-docs" style={{width: "80%"}}/>
+</div>
+<br/>
+
+### Modèle
+
+import Model from '@site/docs/assets/basics/openai_model.webp';
+
+<div className="flex flex-col sm:flex-row justify-between">
+  <div>
+    Cliquez sur le menu déroulant Model à droite de la page. Ce menu vous permet de changer le modèle que vous utilisez. Chaque mode a plusieurs modèles, mais nous nous concentrerons sur ceux de chat. Cette liste semble très compliquée (que veut dire gpt-3.5-turbo ?), mais ce sont juste des noms techniques pour les modèles différents. Tout ce qui commence par gpt-3.5-turbo est une version de ChatGPT, tandis que tout ce qui commence par gpt-4 est une version de GPT-4, le modèle plus récent auquel vous avez accès en achetant un abonnement ChatGPT Plus.
+  </div>
+  <div className="mt-4 sm:mt-0 sm:ml-auto">
+    <img src={Model} className="img-docs w-20 sm:w-auto" />
+  </div>
+</div>
+
+:::note
+Vous ne verrez peut-être pas les versions GPT-4 dans votre interface.
+:::
+
+Les nombres comme 16K, 32K ou 128k dans les noms des modèles représentent la longueur de contexte. Si elle n'est pas spécifiée, la longueur de contexte par défaut est de 4K pour gpt-3.5 et 8k pour GPT-4. OpenAI met régulièrement à jour à la fois ChatGPT (gpt-3.5-turbo) et GPT-4, et les anciennes versions restent disponibles sur la plateforme pour une période limitée. Ces anciens modèles ont des numéros supplémentaires à la fin de leur nom, comme "0613". Par exemple, le modèle "gpt-3.5-turbo-16k-0613" est un modèle ChatGPT avec une longueur de contexte de 16K, sorti le 13 juin 2023. Cependant, il est recommandé d'utiliser les versions les plus récentes des modèles, qui ne contiennent aucune information de date. Une liste complète des versions des modèles peut être trouvée [ici](https://platform.openai.com/docs/models/gpt-4).
+
+## Conclusion
+
+L'OpenAI Playground est un outil puissant qui offre une interface plus avancée pour interagir avec ChatGPT et d'autres modèles d'IA. Il propose une gamme d'options de configuration, y compris la possibilité de sélectionner de différents modèles et modes. Nous apprendrons sur le reste des paramètres dans la [prochaine leçon](https://learnprompting.org/docs/basics/configuration_hyperparameters). Le Playground prend également en charge les system prompts, qui peuvent être utilisés pour guider les réponses de l'IA. Bien que l'interface puisse sembler complexe au début, avec de la pratique, elle devient une ressource précieuse pour explorer les capacités des modèles d'OpenAI. Que vous utilisiez les dernières versions de ChatGPT ou GPT-4, ou que vous exploriez des modèles plus anciens, le Playground offre une plateforme flexible et robuste pour l'interaction et l'expérimentation avec l'IA.
+
+Partiellement écrit par evintunador


### PR DESCRIPTION
slight iteration on the prompt i used for https://github.com/trigaten/Learn_Prompting/pull/1119 and https://github.com/trigaten/Learn_Prompting/pull/1122 after noticing a pattern of what i had to manually fix.

- i still had to do some minor tweaks, notably changing "Définissez" to "Spécifiez" so that the SEPAL acronym works (DEPAL or other variations didn't match up well to somewhat well-known words), and updating other instances within this .md file for consistency

    <img width="621" alt="s_for_sepal_acronym_to_work" src="https://github.com/trigaten/Learn_Prompting/assets/18131787/1d44021b-1212-44de-b578-6aa69051ba03">

- prefixed the prompt with "You are a professional English-to-French translator familiar with the phrasings of technical topics and markdown format."

- inserted "Remember that French uses sentence case for headings, but preserve the casing of English words." in the pre-instruction part of the prompt

- inserted "Note that "Generative AI" should be translated as "IA générative" (generative as in generating) instead of "IA générationnelle" (generational as in generations in a family tree). the ambiguity is due to the short form "genAI" and both words starting with "gen"
  - references for the curious: https://en.wiktionary.org/wiki/generative_AI#English and quick google searches to see the number of results for both: ["ia générationnelle"](https://www.google.com/search?q=%22ia+g%C3%A9n%C3%A9rationnelle%22) vs ["ia générative"](https://www.google.com/search?q="ia+générative"))

- inserted "and "feedback" should be translated as "commentaires"." since i've come across that translation issue a few times already "retour" is a little ambiguous and is translated as "commentaires" when i use UIs in french anyways

- as per usual, i omitted the `sidebar_position` part from the prompt since i already know that has to be exactly the same

```txt
You are a professional English-to-French translator familiar with the phrasings of technical topics and markdown format. Translate the following English text in markdown format (surrounded by dashes) into French text in markdown format. Do not translate "Prompt Engineering" or "PE" or "prompting", just leave those words in English, but otherwise translate the rest of the text. For example, "Prompt Engineering Strategies" should be translated as "Stratégies de Prompt Engineering", and "PE strategies" should be translated as "Stratégies de PE". Note that "Generative AI" should be translated as "IA générative", and "feedback" should be translated as "commentaires". Also do not translate special syntax like ":::takeaways" or ":::caution". Remember that French uses sentence case for headings, but preserve the casing of English words.

-----start of English markdown:-----

...

-----End of English markdown-----

-----French:-----
```